### PR TITLE
chore: Add .npmrc for GitHub Packages registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@nicxe:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary
- Add .npmrc configuration to resolve @nicxe scoped packages from GitHub Packages

This fixes Dependabot failing to update `@nicxe/semantic-release-config` due to the package being hosted on GitHub Packages instead of npmjs.com.

## Test plan
- Verify Dependabot can now successfully check for updates to @nicxe scoped packages
- Confirm npm install works correctly with the new registry configuration

🤖 Generated with [Claude Code](https://claude.ai/code)