### PR TITLE
chore: Add pull_request trigger to validate workflow

### DIFF
--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -3,6 +3,7 @@ name: Validate
 on:
   push:
     branches: [dev, beta, main]
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add pull_request trigger to validate workflow so it runs on all PRs

This was missed in the previous .npmrc PR merge. Without this trigger, validate workflow only runs on pushes to dev/beta/main branches, not on PRs from other branches.

## Test plan
- Verify this PR triggers the validate workflow
- Future PRs from any branch will have validate checks

🤖 Generated with [Claude Code](https://claude.ai/code)