### PR TITLE
chore: Add replaces-base to Dependabot registry config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
+    replaces-base: true
 
 updates:
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Adds `replaces-base: true` to the GitHub Packages registry configuration for Dependabot
- This helps Dependabot properly resolve scoped packages from GitHub Packages

## Test plan
- [ ] Verify Dependabot can now authenticate and update @nicxe/semantic-release-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)