### PR TITLE
fix: Update package-lock.json to use npmjs.com registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@nicxe:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "homeassistant-trafikinfo-se",
+  "name": "homeassistant-trafikinfo-se-temp",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@nicxe/semantic-release-config": {
-      "version": "1.0.7",
-      "resolved": "https://npm.pkg.github.com/download/@nicxe/semantic-release-config/1.0.7/18e931f0f1384759818cda5383c400fce0afb17b",
-      "integrity": "sha512-C70Sjju+dJGHMWIQWuFdwbPwL5Hc+NwdtGJ+1+NSyx7kwNjcbW2rM/DqPOvwHSf1VlMHKtyH6rqpNPNzcLj5KA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nicxe/semantic-release-config/-/semantic-release-config-1.1.1.tgz",
+      "integrity": "sha512-X3HkpRlMfnJEo/oZg/H8YHJt9dfcmFEBt74x4C3/0bZl3F5rRc0HsaPcMHzd0QLATz0DZee7HH8KVHUflGGsaw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -143,6 +143,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -341,6 +342,7 @@
       "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -374,6 +376,7 @@
       "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^3.0.0",
@@ -395,6 +398,7 @@
       "integrity": "sha512-qyqLS+aSGH1SfXIooBKjs7mvrv0deg8v+jemegfJg1kq6ji+GJV8CO08VJDEsvjp3O8XJmTTIAjjZbMzagzsdw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/core": "^7.0.0",
         "@octokit/plugin-paginate-rest": "^14.0.0",
@@ -623,6 +627,7 @@
       "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -1086,6 +1091,7 @@
       "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
@@ -2228,6 +2234,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4407,6 +4414,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4996,6 +5004,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -5745,6 +5754,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5816,9 +5826,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
+      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Update `@nicxe/semantic-release-config` to resolve from npmjs.com instead of GitHub Packages
- Remove `.npmrc` file (no longer needed)
- Bumps version to 1.1.1

## Why
This fixes Dependabot authentication failures. The package is now published to npmjs.com which doesn't require authentication for public packages.