### PR TITLE
fix: ***Prevent oversized traffic event attributes from being stored …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 custom_components/trafikinfo_se.zip
 custom_components/trafikinfo_se/.vscode/settings.json
 custom_components/trafikinfo_se/releasenote.md
+/custom_components/trafikinfo_se/tests

--- a/custom_components/trafikinfo_se/sensor.py
+++ b/custom_components/trafikinfo_se/sensor.py
@@ -260,6 +260,7 @@ class TrafikinfoMessageTypeSensor(
 
     entity_description: TrafikinfoSensorEntityDescription
     _attr_has_entity_name = False
+    _unrecorded_attributes = frozenset({"events"})
     _EVENT_PUBLISH_TYPES = {"Hinder", "Olycka"}
 
     def __init__(


### PR DESCRIPTION
…in Recorder**

Traffic event sensors now keep showing the same detailed information in Home Assistant while avoiding Recorder database writes for the heavy event list. This removes repeated maximum-size attribute warnings and reduces unnecessary database load. Existing dashboards, templates, and automations can continue using the live sensor data without changes.