### PR TITLE
fix: **Correct road filter to apply to all traffic message types by d…

### DIFF
--- a/custom_components/trafikinfo_se/const.py
+++ b/custom_components/trafikinfo_se/const.py
@@ -24,6 +24,8 @@ CONF_SORT_LOCATION = "sort_location"
 
 # Road filtering
 CONF_FILTER_ROADS = "filter_roads"
+CONF_ROAD_FILTER_SAFETY_BYPASS = "road_filter_safety_bypass"
+DEFAULT_ROAD_FILTER_SAFETY_BYPASS = False
 
 SORT_MODE_RELEVANCE = "relevance"  # important -> nearest -> newest
 SORT_MODE_NEAREST = "nearest"  # nearest -> newest

--- a/custom_components/trafikinfo_se/sensor.py
+++ b/custom_components/trafikinfo_se/sensor.py
@@ -525,6 +525,9 @@ class TrafikinfoMessageTypeSensor(
                 "filter_mode": getattr(self.coordinator, "filter_mode", None),
                 "filter_counties": getattr(self.coordinator, "counties", None),
                 "filter_roads": getattr(self.coordinator, "filter_roads", None),
+                "filter_road_safety_bypass": getattr(
+                    self.coordinator, "road_filter_safety_bypass", None
+                ),
                 "filter_center": {
                     "latitude": getattr(self.coordinator, "latitude", None),
                     "longitude": getattr(self.coordinator, "longitude", None),

--- a/custom_components/trafikinfo_se/strings.json
+++ b/custom_components/trafikinfo_se/strings.json
@@ -25,7 +25,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "configure_counties": {
@@ -38,7 +42,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "reconfigure_filter_mode": {
@@ -58,7 +66,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "reconfigure_counties": {
@@ -71,7 +83,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
     },
@@ -101,7 +117,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "counties": {
@@ -114,7 +134,11 @@
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
     },
@@ -145,4 +169,3 @@
     }
   }
 }
-

--- a/custom_components/trafikinfo_se/translations/en.json
+++ b/custom_components/trafikinfo_se/translations/en.json
@@ -22,11 +22,14 @@
           "location": "Center position",
           "radius_km": "Radius (km)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "configure_counties": {
@@ -36,11 +39,14 @@
           "counties": "Counties",
           "sort_location": "Reference position (for selection/sorting)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "reconfigure_filter_mode": {
@@ -57,11 +63,14 @@
           "location": "Center position",
           "radius_km": "Radius (km)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "reconfigure_counties": {
@@ -71,11 +80,14 @@
           "counties": "Counties",
           "sort_location": "Reference position (for selection/sorting)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
     },
@@ -102,11 +114,14 @@
           "location": "Center position",
           "radius_km": "Radius (km)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
       "counties": {
@@ -116,11 +131,14 @@
           "counties": "Counties",
           "sort_location": "Reference position (for selection/sorting)",
           "filter_roads": "Road filter (road numbers/names)",
-          "filter_roads": "Road filter (road numbers/names)",
           "name": "Name",
           "max_items": "Max items in attributes",
           "sort_mode": "Selection / sorting",
-          "message_types": "Message types (categories)"
+          "message_types": "Message types (categories)",
+          "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
     },

--- a/custom_components/trafikinfo_se/translations/sv.json
+++ b/custom_components/trafikinfo_se/translations/sv.json
@@ -25,7 +25,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
       "configure_counties": {
@@ -38,7 +42,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
       "reconfigure_filter_mode": {
@@ -58,7 +66,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
       "reconfigure_counties": {
@@ -71,7 +83,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       }
     },
@@ -101,7 +117,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
       "counties": {
@@ -114,7 +134,11 @@
           "name": "Namn",
           "max_items": "Max antal händelser i attribut",
           "sort_mode": "Urval / sortering",
-          "message_types": "Meddelandetyper (kategorier)"
+          "message_types": "Meddelandetyper (kategorier)",
+          "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
+        },
+        "data_description": {
+          "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       }
     },


### PR DESCRIPTION
…efault**

A new setting, "Bypass road filter for safety-related messages", has been added to the integration configuration. Previously, events of the type Trafikmeddelande were incorrectly shown regardless of any configured road filter, because they were treated as safety-related by default. The road filter now applies strictly to all event types, including Trafikmeddelande, unless the bypass setting is explicitly enabled. Existing setups with a road filter configured may see fewer events for Trafikmeddelande after this update, which reflects the intended filtering behavior. The bypass can be enabled in the integration options if the previous behavior is preferred.