### PR TITLE
feat: Bundle and auto-manage the Trafikinfo SE alert card

### DIFF
--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -33,4 +33,4 @@ jobs:
           node-version: "22"
 
       - name: Check card syntax
-        run: node --experimental-default-type=module --check www/trafikinfo-se-alert-card.js
+        run: node --experimental-default-type=module --check custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ node_modules/
 custom_components/trafikinfo_se.zip
 custom_components/trafikinfo_se/.vscode/settings.json
 custom_components/trafikinfo_se/releasenote.md
-/custom_components/trafikinfo_se/tests
+__pycache__/
+*.py[cod]
+/custom_components/trafikinfo_se/tests/*
+!/custom_components/trafikinfo_se/tests/test_frontend_resources.py

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,12 +4,13 @@
 This guide is for users who previously installed the alert card from `Nicxe/homeassistant-trafikinfo-se-card`.
 
 ## What changed?
-The integration remains in `Nicxe/homeassistant-trafikinfo-se`, while the card is distributed as a HACS Dashboard plugin from `Nicxe/homeassistant-trafikinfo-se-card` to preserve normal HACS card behavior.
+The card is now bundled directly in `Nicxe/homeassistant-trafikinfo-se` and is managed by the integration itself.
+The integration syncs the bundled card to `/config/www/trafikinfo-se-alert-card.js` and keeps the Lovelace resource at `/local/trafikinfo-se-alert-card.js?v=...` updated to avoid stale browser cache.
 
 ## What you need to do
 1. Install or update the integration from `Nicxe/homeassistant-trafikinfo-se` in HACS as type **Integration**.
-2. Install or update the card from `Nicxe/homeassistant-trafikinfo-se-card` in HACS as type **Dashboard**.
-3. Let HACS manage the card placement in `www/community/` and resource registration.
+2. Remove `Nicxe/homeassistant-trafikinfo-se-card` from HACS if it is still installed.
+3. Keep existing Lovelace cards as-is. The integration keeps `/local/trafikinfo-se-alert-card.js?v=...` updated automatically.
 4. Hard refresh the browser (or clear frontend cache) after updates.
 
 ## Integration users

--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ You can also add the repository manually in HACS as type **Integration**.
 3. Restart Home Assistant.
 
 ### Alert card installation
-For normal HACS dashboard-card behavior (install in `www/community/...` and automatic resource handling by HACS), install the card from:
-- `https://github.com/Nicxe/homeassistant-trafikinfo-se-card`
+The alert card is bundled with this integration.
 
-The integration and card are developed together, but distributed through separate HACS categories:
-- Integration from `homeassistant-trafikinfo-se` (type: Integration)
-- Card from `homeassistant-trafikinfo-se-card` (type: Dashboard)
+When the integration starts, it automatically:
+- syncs the bundled card to `config/www/trafikinfo-se-alert-card.js`
+- creates or updates a Lovelace `module` resource at `/local/trafikinfo-se-alert-card.js?v=...` for cache-busting
 
 ## Configuration
 To add the integration, use this My button:
@@ -59,6 +58,7 @@ Each event includes fields such as `incident_key`, `change_type`, `message_type`
 ## Release assets and versioning
 Each GitHub release in this repository publishes:
 - `trafikinfo_se.zip` for integration installation
+- `trafikinfo-se-alert-card.js` as a standalone fallback asset
 
 The project uses one shared version across integration and card.
 

--- a/custom_components/trafikinfo_se/__init__.py
+++ b/custom_components/trafikinfo_se/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     SERVICE_RESTORE_ALL_EVENTS,
     SERVICE_RESTORE_EVENT,
 )
+from .frontend import async_setup_frontend
 from .coordinator import TrafikinfoCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,6 +83,7 @@ def _get_dismissed_events(entry: ConfigEntry) -> dict[str, dict]:
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the integration (YAML is not supported)."""
+    await async_setup_frontend(hass)
     await _async_register_services(hass)
     return True
 

--- a/custom_components/trafikinfo_se/const.py
+++ b/custom_components/trafikinfo_se/const.py
@@ -10,6 +10,15 @@ if TYPE_CHECKING:
 
 DOMAIN = "trafikinfo_se"
 
+# Frontend card resource handling
+CARD_FILENAME = "trafikinfo-se-alert-card.js"
+CARD_WWW_DIR = "www"
+CARD_STATIC_BASE_PATH = f"/{DOMAIN}-static"
+CARD_CANONICAL_BASE_URL = f"{CARD_STATIC_BASE_PATH}/{CARD_FILENAME}"
+CARD_LEGACY_BASE_URL = f"/local/{CARD_FILENAME}"
+FRONTEND_DATA_KEY = f"{DOMAIN}_frontend"
+FRONTEND_DATA_COMPONENT_LISTENER = f"{DOMAIN}_component_listener"
+
 CONF_API_KEY = "api_key"
 CONF_MAX_ITEMS = "max_items"
 CONF_MESSAGE_TYPES = "message_types"

--- a/custom_components/trafikinfo_se/frontend.py
+++ b/custom_components/trafikinfo_se/frontend.py
@@ -1,0 +1,241 @@
+"""Frontend resource management for Trafikinfo SE card."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from homeassistant.components.lovelace.const import (
+    CONF_RESOURCE_TYPE_WS,
+    CONF_URL,
+    LOVELACE_DATA,
+)
+from homeassistant.const import CONF_ID, CONF_TYPE, EVENT_COMPONENT_LOADED
+from homeassistant.core import Event, HomeAssistant, callback
+
+from .const import (
+    CARD_CANONICAL_BASE_URL,
+    CARD_FILENAME,
+    CARD_LEGACY_BASE_URL,
+    CARD_WWW_DIR,
+    FRONTEND_DATA_COMPONENT_LISTENER,
+    FRONTEND_DATA_KEY,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _card_file_path() -> Path:
+    """Return absolute path to bundled card file."""
+    return Path(__file__).resolve().parent / CARD_WWW_DIR / CARD_FILENAME
+
+
+def _card_www_dir_path() -> Path:
+    """Return absolute path to bundled card www directory."""
+    return Path(__file__).resolve().parent / CARD_WWW_DIR
+
+
+def _local_www_card_path(hass: HomeAssistant) -> Path:
+    """Return target path for /local card file."""
+    return Path(hass.config.path("www")) / CARD_FILENAME
+
+
+def _read_manifest_version() -> str:
+    """Read integration version from manifest.json."""
+    manifest_path = Path(__file__).resolve().parent / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "0.0.0"
+    return str(manifest.get("version", "0.0.0"))
+
+
+def _card_mtime() -> int:
+    """Read card mtime."""
+    card_path = _card_file_path()
+    try:
+        return int(card_path.stat().st_mtime)
+    except OSError:
+        return 0
+
+
+def _read_file_bytes(path: Path) -> bytes:
+    """Read file bytes."""
+    return path.read_bytes()
+
+
+def _write_file_bytes(path: Path, content: bytes) -> None:
+    """Write file bytes atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(content)
+    tmp.replace(path)
+
+
+async def _async_sync_card_to_local_www(hass: HomeAssistant) -> None:
+    """Sync bundled card file into /config/www for /local serving."""
+    source = _card_file_path()
+    target = _local_www_card_path(hass)
+
+    if not source.exists():
+        _LOGGER.warning("Missing bundled card file: %s", source)
+        return
+
+    source_bytes = await hass.async_add_executor_job(_read_file_bytes, source)
+
+    if target.exists():
+        target_bytes = await hass.async_add_executor_job(_read_file_bytes, target)
+        if target_bytes == source_bytes:
+            return
+
+    await hass.async_add_executor_job(_write_file_bytes, target, source_bytes)
+
+
+async def _cache_key_for_dev(hass: HomeAssistant) -> str:
+    """Build cache key from manifest version and card mtime."""
+    version_task = hass.async_add_executor_job(_read_manifest_version)
+    mtime_task = hass.async_add_executor_job(_card_mtime)
+    version, mtime = await asyncio.gather(version_task, mtime_task)
+    return f"{version}-{mtime}"
+
+
+def _url_base(url: str) -> str:
+    """Return URL without query/fragment to allow stable comparisons."""
+    split = urlsplit(url)
+    return urlunsplit((split.scheme, split.netloc, split.path, "", ""))
+
+
+def _url_with_version(base_url: str, cache_key: str) -> str:
+    """Set/update the `v` query parameter for cache-busting."""
+    split = urlsplit(base_url)
+    query = dict(parse_qsl(split.query, keep_blank_values=True))
+    query["v"] = cache_key
+    return urlunsplit(
+        (
+            split.scheme,
+            split.netloc,
+            split.path,
+            urlencode(query, doseq=True),
+            split.fragment,
+        )
+    )
+
+
+async def _async_get_lovelace_resources(hass: HomeAssistant):
+    """Return Lovelace resource collection or None if unavailable."""
+    lovelace_data = hass.data.get(LOVELACE_DATA)
+    if lovelace_data is None:
+        return None
+
+    resources = getattr(lovelace_data, "resources", None)
+    if resources is None:
+        return None
+
+    if hasattr(resources, "loaded") and not resources.loaded and hasattr(
+        resources, "async_load"
+    ):
+        await resources.async_load()
+        resources.loaded = True
+
+    return resources
+
+
+async def _async_ensure_card_resource(hass: HomeAssistant) -> bool:
+    """Create/update Lovelace module resource for the card."""
+    cache_key = await _cache_key_for_dev(hass)
+    desired_url = _url_with_version(CARD_LEGACY_BASE_URL, cache_key)
+
+    try:
+        resources = await _async_get_lovelace_resources(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Unable to load Lovelace resources: %s", err)
+        resources = None
+
+    if resources is None:
+        _LOGGER.debug(
+            "Lovelace resources API unavailable, skipping card resource sync for %s",
+            desired_url,
+        )
+        return False
+
+    try:
+        items: list[dict[str, Any]] = list(resources.async_items() or [])
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Unable to list Lovelace resources: %s", err)
+        return False
+
+    local_item = None
+    legacy_item = None
+    for item in items:
+        url = item.get(CONF_URL)
+        if not isinstance(url, str):
+            continue
+        base = _url_base(url)
+        if base == CARD_LEGACY_BASE_URL:
+            local_item = item
+            break
+        if base == CARD_CANONICAL_BASE_URL:
+            legacy_item = item
+
+    target = local_item or legacy_item
+
+    if target is not None:
+        if (
+            target.get(CONF_URL) == desired_url
+            and target.get(CONF_TYPE) == "module"
+        ):
+            return True
+
+        try:
+            await resources.async_update_item(
+                target[CONF_ID],
+                {CONF_URL: desired_url, CONF_RESOURCE_TYPE_WS: "module"},
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Unable to update Lovelace resource: %s", err)
+            return False
+        return True
+
+    try:
+        await resources.async_create_item(
+            {CONF_URL: desired_url, CONF_RESOURCE_TYPE_WS: "module"}
+        )
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Unable to create Lovelace resource: %s", err)
+        return False
+
+    return True
+
+
+def _async_component_loaded_listener(hass: HomeAssistant) -> Callable[[], None]:
+    """Create component-loaded listener for late Lovelace startup."""
+
+    @callback
+    def _handle_component_loaded(event: Event) -> None:
+        if event.data.get("component") not in ("lovelace", "frontend"):
+            return
+        hass.async_create_task(_async_ensure_card_resource(hass))
+
+    return hass.bus.async_listen(EVENT_COMPONENT_LOADED, _handle_component_loaded)
+
+
+async def async_setup_frontend(hass: HomeAssistant) -> None:
+    """Set up static card path and Lovelace resource."""
+    state: dict[str, Any] = hass.data.setdefault(FRONTEND_DATA_KEY, {})
+    if state.get("setup_done"):
+        return
+
+    await _async_sync_card_to_local_www(hass)
+    await _async_ensure_card_resource(hass)
+
+    if FRONTEND_DATA_COMPONENT_LISTENER not in hass.data:
+        hass.data[FRONTEND_DATA_COMPONENT_LISTENER] = _async_component_loaded_listener(
+            hass
+        )
+
+    state["setup_done"] = True

--- a/custom_components/trafikinfo_se/manifest.json
+++ b/custom_components/trafikinfo_se/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/Nicxe/homeassistant-trafikinfo-se",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nicxe/homeassistant-trafikinfo-se/issues",
+  "after_dependencies": ["lovelace"],
   "version": "0.0.0"
 }
-
 

--- a/custom_components/trafikinfo_se/manifest.json
+++ b/custom_components/trafikinfo_se/manifest.json
@@ -1,12 +1,11 @@
 {
   "domain": "trafikinfo_se",
   "name": "Trafikinfo SE",
+  "after_dependencies": ["lovelace"],
   "codeowners": ["@Nicxe"],
   "config_flow": true,
   "documentation": "https://github.com/Nicxe/homeassistant-trafikinfo-se",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nicxe/homeassistant-trafikinfo-se/issues",
-  "after_dependencies": ["lovelace"],
   "version": "0.0.0"
 }
-

--- a/custom_components/trafikinfo_se/tests/test_frontend_resources.py
+++ b/custom_components/trafikinfo_se/tests/test_frontend_resources.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.components.lovelace.const import LOVELACE_DATA
+from homeassistant.const import CONF_ID, CONF_TYPE
+
+from custom_components.trafikinfo_se import frontend
+from custom_components.trafikinfo_se.const import CARD_CANONICAL_BASE_URL, CARD_LEGACY_BASE_URL
+
+
+class _FakeResources:
+    def __init__(self, items: list[dict] | None = None) -> None:
+        self._items = list(items or [])
+        self.loaded = False
+        self.create_calls = 0
+        self.update_calls = 0
+
+    async def async_load(self) -> None:
+        self.loaded = True
+
+    def async_items(self) -> list[dict]:
+        return list(self._items)
+
+    async def async_create_item(self, data: dict) -> dict:
+        self.create_calls += 1
+        item = {
+            CONF_ID: f"generated-{self.create_calls}",
+            "url": data["url"],
+            CONF_TYPE: data.get("res_type", "module"),
+        }
+        self._items.append(item)
+        return item
+
+    async def async_update_item(self, item_id: str, updates: dict) -> dict:
+        self.update_calls += 1
+        for item in self._items:
+            if item[CONF_ID] == item_id:
+                item["url"] = updates["url"]
+                if "res_type" in updates:
+                    item[CONF_TYPE] = updates["res_type"]
+                return item
+        raise KeyError(item_id)
+
+
+@pytest.fixture
+def hass():
+    return SimpleNamespace(data={})
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_creates_when_missing(hass, monkeypatch) -> None:
+    resources = _FakeResources()
+    hass.data[LOVELACE_DATA] = SimpleNamespace(resources=resources)
+
+    async def _fake_cache_key(_hass):
+        return "0.0.0-123"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is True
+    assert resources.create_calls == 1
+    created = resources.async_items()[0]
+    assert created[CONF_TYPE] == "module"
+    assert created["url"] == f"{CARD_LEGACY_BASE_URL}?v=0.0.0-123"
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_updates_existing_canonical(hass, monkeypatch) -> None:
+    resources = _FakeResources(
+        [
+            {
+                CONF_ID: "abc",
+                CONF_TYPE: "module",
+                "url": f"{CARD_CANONICAL_BASE_URL}?v=old",
+            }
+        ]
+    )
+    hass.data[LOVELACE_DATA] = SimpleNamespace(resources=resources)
+
+    async def _fake_cache_key(_hass):
+        return "0.0.0-456"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is True
+    assert resources.update_calls == 1
+    assert resources.async_items()[0]["url"] == f"{CARD_LEGACY_BASE_URL}?v=0.0.0-456"
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_prefers_existing_local_over_canonical(
+    hass, monkeypatch
+) -> None:
+    resources = _FakeResources(
+        [
+            {CONF_ID: "local", CONF_TYPE: "module", "url": CARD_LEGACY_BASE_URL},
+            {CONF_ID: "canonical", CONF_TYPE: "module", "url": CARD_CANONICAL_BASE_URL},
+        ]
+    )
+    hass.data[LOVELACE_DATA] = SimpleNamespace(resources=resources)
+
+    async def _fake_cache_key(_hass):
+        return "0.0.0-789"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is True
+    assert resources.update_calls == 1
+    items = {item[CONF_ID]: item for item in resources.async_items()}
+    assert items["local"]["url"] == f"{CARD_LEGACY_BASE_URL}?v=0.0.0-789"
+    assert items["canonical"]["url"] == CARD_CANONICAL_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_is_idempotent(hass, monkeypatch) -> None:
+    resources = _FakeResources(
+        [
+            {
+                CONF_ID: "abc",
+                CONF_TYPE: "module",
+                "url": f"{CARD_LEGACY_BASE_URL}?v=stable",
+            }
+        ]
+    )
+    hass.data[LOVELACE_DATA] = SimpleNamespace(resources=resources)
+
+    async def _fake_cache_key(_hass):
+        return "stable"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is True
+    assert resources.create_calls == 0
+    assert resources.update_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_migrates_canonical_to_local(hass, monkeypatch) -> None:
+    resources = _FakeResources(
+        [
+            {
+                CONF_ID: "canonical",
+                CONF_TYPE: "module",
+                "url": f"{CARD_CANONICAL_BASE_URL}?v=old",
+            }
+        ]
+    )
+    hass.data[LOVELACE_DATA] = SimpleNamespace(resources=resources)
+
+    async def _fake_cache_key(_hass):
+        return "0.0.0-999"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is True
+    assert resources.update_calls == 1
+    assert resources.async_items()[0]["url"] == f"{CARD_LEGACY_BASE_URL}?v=0.0.0-999"
+
+
+@pytest.mark.asyncio
+async def test_ensure_resource_falls_back_without_lovelace(hass, monkeypatch) -> None:
+    async def _fake_cache_key(_hass):
+        return "fallback"
+
+    monkeypatch.setattr(frontend, "_cache_key_for_dev", _fake_cache_key)
+
+    ok = await frontend._async_ensure_card_resource(hass)
+
+    assert ok is False

--- a/custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
+++ b/custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
@@ -3,9 +3,8 @@
  * - www/smhi-alert-card.js
  * - www/krisinformation-alert-card.js
  */
-// Använd HA:s inbyggda Lit om tillgängligt, annars fallback till CDN
+// Använd HA:s inbyggda Lit om tillgängligt, annars fallback till CDN.
 const getLit = async () => {
-  // Home Assistant 2023.4+ exponerar Lit globalt
   if (window.LitElement && window.litHtml) {
     return {
       LitElement: window.LitElement,
@@ -13,7 +12,25 @@ const getLit = async () => {
       css: window.litHtml.css,
     };
   }
-  // Fallback för äldre HA-versioner eller fristående testning
+
+  // Try known HA frontend classes without waiting forever.
+  const candidates = ['ha-panel-lovelace', 'hui-masonry-view', 'hui-view'];
+  for (const name of candidates) {
+    const el = customElements.get(name);
+    if (!el) {
+      continue;
+    }
+    const base = Object.getPrototypeOf(el);
+    if (base?.prototype?.html && base?.prototype?.css) {
+      return {
+        LitElement: base,
+        html: base.prototype.html,
+        css: base.prototype.css,
+      };
+    }
+  }
+
+  // Last fallback for older HA versions or standalone testing.
   return import('https://unpkg.com/lit@3.1.0?module');
 };
 

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -7,6 +7,10 @@ const config = require("@nicxe/semantic-release-config")({
     {
       path: "custom_components/trafikinfo_se.zip",
       label: "trafikinfo_se.zip"
+    },
+    {
+      path: "custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js",
+      label: "trafikinfo-se-alert-card.js"
     }
   ]
 });


### PR DESCRIPTION
This PR bundles the Trafikinfo SE Lovelace card inside the integration and auto-manages the card resource in Home Assistant.

It moves the card to `custom_components/trafikinfo_se/www`, adds frontend resource orchestration, keeps `/local/trafikinfo-se-alert-card.js?v=...` updated for cache-busting, and preserves legacy compatibility by updating existing resources in place. It also updates CI, release config, and docs to match the new flow, and includes frontend resource tests.

Validation done:
- `ruff check` on updated Python files
- `node --check` on the bundled card file
- `pytest -q custom_components/trafikinfo_se/tests/test_frontend_resources.py` (6 passed)
- `semantic-release --dry-run` with Node 22
