### PR TITLE
feat(issues): add component selector and automatic integration/card labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -4,6 +4,18 @@ title: "[Bug]: "
 labels: ["bug"]
 assignees: ["Nicxe"]
 body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part is affected? This is used to auto-label the issue.
+      options:
+        - Integration
+        - Alert Card
+        - Both
+    validations:
+      required: true
+
   - type: checkboxes
     id: prerequisites
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -4,6 +4,18 @@ title: "[Feature]: "
 labels: ["enhancement"]
 assignees: ["Nicxe"]
 body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part should be improved? This is used to auto-label the issue.
+      options:
+        - Integration
+        - Alert Card
+        - Both
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,27 @@
 name: ❓ Question
-description: Ask a question about Trafikinfo SE
+description: Ask a question about Trafikinfo SE (integration or card)
 labels: ["question"]
 body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part is your question about? This is used to auto-label the issue.
+      options:
+        - Integration
+        - Alert Card
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true
+
   - type: markdown
     attributes:
       value: |

--- a/.github/workflows/label-issue-component.yml
+++ b/.github/workflows/label-issue-component.yml
@@ -1,0 +1,102 @@
+name: Label issue component
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  apply-component-labels:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request == null }}
+    steps:
+      - name: Apply integration/card labels from issue form
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || "";
+
+            const componentMatch = body.match(/###\s*Component\s*\r?\n+([^\r\n]+)/i);
+            if (!componentMatch) {
+              core.info("No component section found in issue body.");
+              return;
+            }
+
+            const componentValue = componentMatch[1].trim().toLowerCase();
+            core.info(`Component selected: ${componentValue}`);
+
+            const labelDefs = {
+              integration: {
+                color: "1D76DB",
+                description: "Issue affects the Trafikinfo SE integration",
+              },
+              card: {
+                color: "5319E7",
+                description: "Issue affects the Trafikinfo SE Lovelace card",
+              },
+            };
+
+            const targetLabels = [];
+            if (componentValue.includes("both")) {
+              targetLabels.push("integration", "card");
+            } else if (componentValue.includes("integration")) {
+              targetLabels.push("integration");
+            } else if (componentValue.includes("card") || componentValue.includes("alert")) {
+              targetLabels.push("card");
+            }
+
+            if (!targetLabels.length) {
+              core.info("No mapped labels for component value.");
+              return;
+            }
+
+            for (const [name, meta] of Object.entries(labelDefs)) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: meta.color,
+                  description: meta.description,
+                });
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: targetLabels,
+            });
+
+            const labelsToRemove = Object.keys(labelDefs).filter(
+              (label) => !targetLabels.includes(label)
+            );
+
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
This PR improves issue triage by making issue templates explicitly component-aware and automatically labeling issues.

Changes included:
- Added a required **Component** selector to bug reports, feature requests, and questions (`Integration`, `Alert Card`, `Both`).
- Added a new workflow that runs on issue open/edit/reopen and applies `integration` and/or `card` labels based on the selected component.
- Workflow also creates the labels if they do not exist yet and keeps labels in sync when the component selection changes.

This keeps triage consistent and makes filtering issue queues easier.
