### PR TITLE
chore: update issue templates for integration and card

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,7 @@ body:
       description: Which part is affected?
       options:
         - Integration
-        - Alert Card
+        - Card
         - Both
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: 💬 Questions & Support
-    url: https://community.home-assistant.io/t/trafikinfo-se-real-time-swedish-traffic-alerts-for-home-assistant/973654
-    about: For questions, help, and discussions, please use the Home Assistant community thread.
-  - name: 📖 Documentation
-    url: https://github.com/Nicxe/homeassistant-trafikinfo-se
-    about: Check documentation and migration notes before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,7 +11,7 @@ body:
       description: Which part should be improved?
       options:
         - Integration
-        - Alert Card
+        - Card
         - Both
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -2,8 +2,28 @@ name: ❓ Question
 description: Ask a question about Trafikinfo SE (integration or card)
 labels: ["question"]
 body:
-  - type: markdown
+  - type: dropdown
+    id: component
     attributes:
-      value: |
-        Please use the Home Assistant Community Forum for support and questions:
-        https://community.home-assistant.io/t/trafikinfo-se-real-time-swedish-traffic-alerts-for-home-assistant/973654
+      label: Component
+      description: What is your question about?
+      options:
+        - Integration
+        - Card
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: Describe what you need help with.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Share relevant details, configuration, and what you already tried.

--- a/.github/workflows/label-component.yml
+++ b/.github/workflows/label-component.yml
@@ -1,0 +1,65 @@
+name: Label Issue Component
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply component label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const body = context.payload.issue.body || '';
+
+            const match = body.match(/### Component\s*\n+([^\n]+)/i);
+            if (!match) {
+              core.info('No component section found in issue body.');
+              return;
+            }
+
+            const selected = match[1].trim().toLowerCase();
+            const integrationLabel = 'Integration';
+            const cardLabel = 'Card';
+
+            let desired = [];
+            if (selected === 'integration') desired = [integrationLabel];
+            if (selected === 'card') desired = [cardLabel];
+            if (selected === 'both') desired = [integrationLabel, cardLabel];
+
+            if (desired.length === 0) {
+              core.info(`Unknown component value: ${selected}`);
+              return;
+            }
+
+            for (const label of [integrationLabel, cardLabel]) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name: label, color: '0e8a16' });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            const currentLabels = context.payload.issue.labels.map((l) => l.name);
+            const toAdd = desired.filter((l) => !currentLabels.includes(l));
+            const toRemove = [integrationLabel, cardLabel].filter((l) => !desired.includes(l) && currentLabels.includes(l));
+
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+            }
+
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+            }


### PR DESCRIPTION
Standardizes issue templates so users can choose whether an issue is for the integration, card, or both, and keeps questions as regular issues.\n\nAlso adds automatic component labeling with `Integration` and `Card` based on the selected template value.