### PR TITLE
fix: restore question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,25 +6,6 @@ body:
     id: component
     attributes:
       label: Component
-      description: Which part is your question about? This is used to auto-label the issue.
-      options:
-        - Integration
-        - Alert Card
-        - Both
-    validations:
-      required: true
-
-  - type: textarea
-    id: question
-    attributes:
-      label: Question
-      description: What do you need help with?
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      label: Component
       description: What is your question about?
       options:
         - Integration


### PR DESCRIPTION
Fixes the Question issue template so it renders correctly and is selectable in the issue chooser.