### PR TITLE
chore: add outdated-version issue automation

### DIFF
--- a/.github/workflows/close-outdated-version-issues.yml
+++ b/.github/workflows/close-outdated-version-issues.yml
@@ -1,0 +1,49 @@
+name: Close Outdated Version Issues
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  close-outdated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues with outdated-version label after 24 hours of inactivity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'outdated-version',
+            });
+
+            for (const issue of issues) {
+              if (new Date(issue.updated_at) < cutoff) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    'This issue has been automatically closed due to no response after the request to update to the latest version.',
+                    '',
+                    'If you are still experiencing this issue after updating, please open a new report with the latest version and relevant logs.',
+                  ].join('\n'),
+                });
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+              }
+            }

--- a/.github/workflows/issue-version-check.yml
+++ b/.github/workflows/issue-version-check.yml
@@ -1,0 +1,86 @@
+name: Issue Version Check
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    steps:
+      - name: Check reported version against latest release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const normalize = v => v.trim().replace(/^v/i, '');
+
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                  description,
+                });
+              } catch {
+                // Label already exists — ignore
+              }
+            };
+
+            const body = context.payload.issue.body || '';
+            const issueNumber = context.payload.issue.number;
+            const existingLabels = context.payload.issue.labels.map(l => l.name);
+
+            // Extract reported version from issue body
+            const versionMatch = body.match(/### Release Version\s*\n+([^\n#]+)/i);
+            if (!versionMatch) return;
+            const reportedVersion = normalize(versionMatch[1]);
+            if (!reportedVersion) return;
+
+            // Skip if already labeled
+            if (existingLabels.includes('outdated-version')) return;
+
+            // Get latest release
+            let latestRelease;
+            try {
+              const { data } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              latestRelease = data;
+            } catch {
+              // No releases yet — nothing to compare against
+              return;
+            }
+
+            const latestVersion = normalize(latestRelease.tag_name);
+
+            if (reportedVersion === latestVersion) return;
+
+            await ensureLabel('outdated-version', 'e4e669', 'Issue reported on an outdated version');
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['outdated-version'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                'Thanks for the report.',
+                '',
+                `You are running version **${reportedVersion}**, but the latest release of Trafikinfo SE is **${latestVersion}**.`,
+                '',
+                'Please update to the latest version and check whether the issue still occurs.',
+                '',
+                'If the issue persists after updating, please comment here and we will continue investigating.',
+                'If we do not hear back within 24 hours, this issue will be automatically closed.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
Adds two issue workflows: one that comments and labels bug reports filed on outdated versions, and one that automatically closes unresolved outdated-version issues after 24 hours.