### PR TITLE
chore: Prevent Dependabot updates from triggering releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -13,6 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
Ensures Dependabot updates are treated as chore changes so semantic-release does not create unnecessary releases. Adds Dependabot commit-message prefixes and enforces a chore merge subject in automerge workflows.