### PR TITLE
fix: Support Telegram Bot notifiers in Trafikinfo SE alert blueprint

### DIFF
--- a/blueprints/trafikinfo_se_notis_olycka_hinder.yaml
+++ b/blueprints/trafikinfo_se_notis_olycka_hinder.yaml
@@ -20,8 +20,9 @@ blueprint:
     notify_additional_services:
       name: Extra notifieringstjänster (valfritt)
       description: >
-        Komma- eller semikolonseparerad lista av `notify.*`-tjänster, t.ex.
-        `notify.telegram`, `notify.notify`.
+        Komma- eller semikolonseparerad lista av notifieringar. Du kan ange både
+        direkta `notify.*`-tjänster och `notify`-entiteter, t.ex.
+        `notify.notify`, `notify.file`, `notify.telegram_bot_chat`.
       default: ""
       selector:
         text: {}
@@ -201,7 +202,7 @@ variables:
     {{ out }}
   road_text: >-
     {{ (road_name ~ ' ' ~ road_number ~ ' ' ~ (incident.location_descriptor | default('', true))) | lower }}
-  notify_services: >-
+  notify_service_targets: >-
     {% set ns = namespace(services=[]) %}
     {% for dev_id in (notify_devices_input | default([])) %}
       {% set name = device_attr(dev_id, 'name') %}
@@ -211,12 +212,32 @@ variables:
     {% endfor %}
     {% set s = (notify_additional_services_raw | default('') | string).replace(';', ',') %}
     {% for raw in s.split(',') %}
-      {% set svc = (raw | trim) %}
-      {% if svc %}
-        {% set ns.services = ns.services + [svc] %}
+      {% set target = (raw | trim) %}
+      {% if target and '.' in target %}
+        {% set parts = target.split('.', 1) %}
+        {% if has_service(parts[0], parts[1]) %}
+          {% set ns.services = ns.services + [target] %}
+        {% endif %}
+      {% elif target %}
+        {% set ns.services = ns.services + [target] %}
       {% endif %}
     {% endfor %}
     {{ ns.services }}
+  notify_entity_targets: >-
+    {% set ns = namespace(entities=[]) %}
+    {% set s = (notify_additional_services_raw | default('') | string).replace(';', ',') %}
+    {% for raw in s.split(',') %}
+      {% set target = (raw | trim) %}
+      {% if target.startswith('notify.') and '.' in target %}
+        {% set parts = target.split('.', 1) %}
+        {% if not has_service(parts[0], parts[1]) %}
+          {% set ns.entities = ns.entities + [target] %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.entities }}
+  notify_target_count: >-
+    {{ (notify_service_targets | default([], true) | count) + (notify_entity_targets | default([], true) | count) }}
   notification_title: >-
     {% set fields = title_fields_input | default([]) %}
     {% if fields is string %}{% set fields = [fields] %}{% endif %}
@@ -296,7 +317,7 @@ variables:
 condition:
   - condition: template
     value_template: >-
-      {{ (notify_services is sequence) and ((notify_services | length) > 0) }}
+      {{ notify_target_count | int(0) > 0 }}
   - condition: template
     value_template: >-
       {% set allowed = source_entities_input | default([]) %}
@@ -342,9 +363,17 @@ condition:
 
 action:
   - repeat:
-      for_each: "{{ notify_services }}"
+      for_each: "{{ notify_service_targets }}"
       sequence:
         - service: "{{ repeat.item }}"
           data:
+            title: "{{ notification_title }}"
+            message: "{{ notification_message }}"
+  - repeat:
+      for_each: "{{ notify_entity_targets }}"
+      sequence:
+        - service: notify.send_message
+          data:
+            entity_id: "{{ repeat.item }}"
             title: "{{ notification_title }}"
             message: "{{ notification_message }}"


### PR DESCRIPTION
The Trafikinfo SE alert blueprint now works with both traditional notify.* services and newer notify entities, including Telegram Bot notifiers. This fixes automation failures where valid notification targets could be rejected as unknown actions, while keeping existing notification setups working as before.

Fixes #71

## Summary

Describe what changed and why.

## Component

- [X] Integration
- [ ] Alert Card
- [ ] CI/Docs/Other

## Validation

- [X] I ran relevant local checks
- [X] I verified release note impact
- [X] I used Conventional Commit format with scope when relevant

## Notes

Include rollout or migration notes if needed.
