### PR TITLE
fix: undvik loggning av exakta koordinater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 /custom_components/trafikinfo_se/tests/*
 !/custom_components/trafikinfo_se/tests/test_frontend_resources.py
+!/custom_components/trafikinfo_se/tests/test_coordinator_logging.py

--- a/custom_components/trafikinfo_se/coordinator.py
+++ b/custom_components/trafikinfo_se/coordinator.py
@@ -1062,10 +1062,8 @@ class TrafikinfoCoordinator(DataUpdateCoordinator[TrafikinfoData]):
             f"{DOMAIN}_icon_cache",
         )
         _LOGGER.debug(
-            "Filter: mode=%s center=(%.5f,%.5f) radius_km=%.1f counties=%s events_before=%s events_after=%s",
+            "Filter: mode=%s radius_km=%.1f counties=%s events_before=%s events_after=%s",
             self._filter_mode,
-            self._latitude,
-            self._longitude,
             self._radius_km,
             sorted(self._counties),
             len(data.events),

--- a/custom_components/trafikinfo_se/tests/test_coordinator_logging.py
+++ b/custom_components/trafikinfo_se/tests/test_coordinator_logging.py
@@ -1,0 +1,32 @@
+"""Regression tests for privacy-safe coordinator logging."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+class CoordinatorLoggingPrivacyTest(unittest.TestCase):
+    """Ensure precise Home Assistant coordinates never reach log calls."""
+
+    def test_log_calls_do_not_receive_precise_coordinates(self) -> None:
+        source_path = Path(__file__).parents[1] / "coordinator.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+        sensitive_log_arguments: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {"debug", "info", "warning", "error", "exception"}:
+                continue
+            for argument in node.args[1:]:
+                rendered = ast.unparse(argument)
+                if rendered in {"self._latitude", "self._longitude"}:
+                    sensitive_log_arguments.append(rendered)
+
+        self.assertEqual([], sensitive_log_arguments)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Sammanfattning
- tar bort latitud och longitud från koordinatorns debuglogg
- behåller ofarlig filterdiagnostik som läge, radie, län och antal händelser
- lägger till ett regressionstest som granskar samtliga logganrop i koordinatorn och stoppar framtida läckage av de privata koordinatfälten

## Verifiering
- `python3 custom_components/trafikinfo_se/tests/test_coordinator_logging.py`
- `python3 -m compileall -q custom_components/trafikinfo_se`
- syntaxkontroll av Lovelace-kortet
- `git diff --check`

## Säkerhetsvarningar
Detta åtgärdar båda CodeQL-fynden `py/clear-text-logging-sensitive-data`. De sex återstående Dependabot-fynden ligger i npm CLI:s bundlade transitiva kopior av `ip-address` och `undici`; de kan inte ersättas av npm overrides. Inga lokala stubbar eller manipulerade låsfiler används.