### PR TITLE
feat: **Improve road filtering in the integration and alert card**

### DIFF
--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -33,4 +33,7 @@ jobs:
           node-version: "22"
 
       - name: Check card syntax
-        run: node --experimental-default-type=module --check custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
+        run: node --check custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
+
+      - name: Test card road filtering
+        run: node --test tests/trafikinfo-road-filter.test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 /custom_components/trafikinfo_se/tests/*
 !/custom_components/trafikinfo_se/tests/test_frontend_resources.py
+!/custom_components/trafikinfo_se/tests/test_road_filter.py

--- a/custom_components/trafikinfo_se/coordinator.py
+++ b/custom_components/trafikinfo_se/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 import logging
@@ -15,7 +14,6 @@ import xml.etree.ElementTree as ET
 
 import aiohttp
 import async_timeout
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
@@ -27,31 +25,31 @@ from .const import (
     CONF_COUNTIES,
     CONF_FILTER_MODE,
     CONF_FILTER_ROADS,
-    CONF_ROAD_FILTER_SAFETY_BYPASS,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_MAX_ITEMS,
     CONF_RADIUS_KM,
+    CONF_ROAD_FILTER_SAFETY_BYPASS,
     CONF_SORT_LOCATION,
     CONF_SORT_MODE,
     COUNTY_ALL,
-    DEFAULT_RADIUS_KM,
     DEFAULT_FILTER_MODE,
     DEFAULT_MAX_ITEMS,
+    DEFAULT_RADIUS_KM,
     DEFAULT_ROAD_FILTER_SAFETY_BYPASS,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SORT_MODE,
     DOMAIN,
     FILTER_MODE_COORDINATE,
     FILTER_MODE_COUNTY,
+    ICON_CACHE_DIR,
     SITUATION_SCHEMA_VERSION,
     SORT_MODE_NEAREST,
     SORT_MODE_NEWEST,
     SORT_MODE_RELEVANCE,
     TRAFIKVERKET_DATACACHE_URL,
-    TRAFIKVERKET_ICONS_BASE_URL,
     TRAFIKVERKET_ICON_V2_URL_PREFIX,
-    ICON_CACHE_DIR,
+    TRAFIKVERKET_ICONS_BASE_URL,
     get_user_agent,
 )
 
@@ -678,14 +676,27 @@ class TrafikinfoCoordinator(DataUpdateCoordinator[TrafikinfoData]):
     def _road_filter_match(self, event: TrafikinfoEvent, tokens: list[str]) -> bool:
         if not tokens:
             return True
-        road_text = f"{event.road_name or ''} {event.road_number or ''}".lower()
-        road_no = (event.road_number or "").strip().lower()
-        for t in tokens:
-            if not t:
+        road_name = re.sub(r"\s+", " ", (event.road_name or "").lower()).strip()
+        road_no = self._normalize_road_filter_token(event.road_number or "")
+        for token in tokens:
+            if not token:
                 continue
-            if road_no and t == road_no:
-                return True
-            if t in road_text:
+
+            if token.endswith("*") and token.count("*") == 1:
+                prefix = token[:-1].strip()
+                if prefix and road_no.startswith(prefix):
+                    return True
+                continue
+
+            if "*" in token:
+                continue
+
+            if any(char.isdigit() for char in token):
+                if road_no and token == road_no:
+                    return True
+                continue
+
+            if token in road_name:
                 return True
         return False
 
@@ -1038,7 +1049,7 @@ class TrafikinfoCoordinator(DataUpdateCoordinator[TrafikinfoData]):
                         )
         except TrafikinfoError as err:
             raise UpdateFailed(str(err)) from err
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise UpdateFailed(
                 "Request timeout - Trafikverket API not responding"
             ) from None

--- a/custom_components/trafikinfo_se/strings.json
+++ b/custom_components/trafikinfo_se/strings.json
@@ -51,6 +51,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -68,6 +69,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -111,6 +113,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -128,6 +131,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
@@ -164,6 +168,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -181,6 +186,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },

--- a/custom_components/trafikinfo_se/tests/test_frontend_resources.py
+++ b/custom_components/trafikinfo_se/tests/test_frontend_resources.py
@@ -250,3 +250,14 @@ def test_bundled_card_editors_expose_tile_provider_fields() -> None:
     assert card_text.count("name: 'map_tile_url'") == 2
     assert card_text.count("name: 'map_tile_attribution'") == 2
     assert card_text.count("name: 'map_tile_max_zoom'") == 2
+
+
+def test_bundled_card_editor_documents_road_filter_matching() -> None:
+    card_path = Path(frontend._card_file_path())
+    card_text = card_path.read_text(encoding="utf-8")
+
+    label = (
+        "Filter roads (exact numbers/names; 71* for prefixes; "
+        "comma/semicolon-separated)"
+    )
+    assert card_text.count(label) == 2

--- a/custom_components/trafikinfo_se/tests/test_road_filter.py
+++ b/custom_components/trafikinfo_se/tests/test_road_filter.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from custom_components.trafikinfo_se.coordinator import (
+    TrafikinfoCoordinator,
+    TrafikinfoEvent,
+)
+
+BASE_EVENT = TrafikinfoEvent(
+    situation_id="situation",
+    deviation_id="deviation",
+    icon_id=None,
+    message_type="Olycka",
+    message_type_value="Accident",
+    header="Test event",
+    message="Test event",
+    severity_code=2,
+    severity_text="Moderate",
+    road_number=None,
+    road_name=None,
+    county_no=[14],
+    affected_direction=None,
+    affected_direction_value=None,
+    start_time=None,
+    end_time=None,
+    valid_until_further_notice=None,
+    suspended=None,
+    location_descriptor=None,
+    positional_description=None,
+    traffic_restriction_type=None,
+    temporary_limit=None,
+    number_of_lanes_restricted=None,
+    safety_related_message=False,
+    weblink=None,
+    geometry_wgs84="POINT (11.97 57.70)",
+    version_time=None,
+    publication_time=None,
+    modified_time=None,
+)
+
+
+@pytest.fixture
+def coordinator() -> TrafikinfoCoordinator:
+    return object.__new__(TrafikinfoCoordinator)
+
+
+@pytest.mark.parametrize(
+    ("token", "road_number", "road_name", "expected"),
+    [
+        ("84", "84", "Väg 84", True),
+        ("84", "848", "Vallervägen (Väg 848)", False),
+        ("e4", "E4", "Europaväg E4", True),
+        ("e4", "E45", "Europaväg E45", False),
+        ("71*", "71", "Väg 71", True),
+        ("71*", "712", "Väg 712", True),
+        ("71*", "713", "Väg 713", True),
+        ("71*", "715", "Väg 715", True),
+        ("71*", "72", "Väg 72", False),
+        ("vallervägen", "848", "Vallervägen (Väg 848)", True),
+        ("valler", "848", "Vallervägen (Väg 848)", True),
+        ("*", "848", "Vallervägen (Väg 848)", False),
+        ("7*1", "711", "Väg 711", False),
+    ],
+)
+def test_road_filter_match(
+    coordinator: TrafikinfoCoordinator,
+    token: str,
+    road_number: str,
+    road_name: str,
+    expected: bool,
+) -> None:
+    event = replace(BASE_EVENT, road_number=road_number, road_name=road_name)
+
+    assert coordinator._road_filter_match(event, [token]) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Väg 84", "84"),
+        ("Road 71*", "71*"),
+        ("  E4  ", "e4"),
+        ("Vallervägen", "vallervägen"),
+    ],
+)
+def test_normalize_road_filter_token(
+    coordinator: TrafikinfoCoordinator, value: str, expected: str
+) -> None:
+    assert coordinator._normalize_road_filter_token(value) == expected
+
+
+def test_apply_road_filter_supports_exact_and_prefix_tokens(
+    coordinator: TrafikinfoCoordinator,
+) -> None:
+    coordinator._filter_roads = ["84", "Väg 71*", "E4"]
+    coordinator._road_filter_safety_bypass = False
+    events = [
+        replace(BASE_EVENT, deviation_id="84", road_number="84", road_name="Väg 84"),
+        replace(
+            BASE_EVENT,
+            deviation_id="848",
+            road_number="848",
+            road_name="Vallervägen (Väg 848)",
+        ),
+        replace(BASE_EVENT, deviation_id="712", road_number="712", road_name="Väg 712"),
+        replace(
+            BASE_EVENT, deviation_id="E4", road_number="E4", road_name="Europaväg E4"
+        ),
+        replace(
+            BASE_EVENT, deviation_id="E45", road_number="E45", road_name="Europaväg E45"
+        ),
+    ]
+
+    filtered = coordinator._apply_road_filter(events)
+
+    assert [event.deviation_id for event in filtered] == ["84", "712", "E4"]

--- a/custom_components/trafikinfo_se/translations/en.json
+++ b/custom_components/trafikinfo_se/translations/en.json
@@ -51,6 +51,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -68,6 +69,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -111,6 +113,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -128,6 +131,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       }
@@ -164,6 +168,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },
@@ -181,6 +186,7 @@
           "road_filter_safety_bypass": "Bypass road filter for safety-related messages"
         },
         "data_description": {
+          "filter_roads": "Separate values with commas or semicolons. Road numbers match exactly; append * for a number prefix (for example, 71*). Road names use case-insensitive text matching.",
           "road_filter_safety_bypass": "If enabled, events marked as safety-related by Trafikverket bypass the road filter and are always shown. 'Viktig trafikinformation' always bypasses the road filter regardless of this setting. Disable to apply road filtering strictly to all event types including Trafikmeddelande."
         }
       },

--- a/custom_components/trafikinfo_se/translations/sv.json
+++ b/custom_components/trafikinfo_se/translations/sv.json
@@ -51,6 +51,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
@@ -68,6 +69,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
@@ -111,6 +113,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
@@ -128,6 +131,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       }
@@ -164,6 +168,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },
@@ -181,6 +186,7 @@
           "road_filter_safety_bypass": "Kringgå vägfilter för säkerhetsrelaterade meddelanden"
         },
         "data_description": {
+          "filter_roads": "Separera värden med kommatecken eller semikolon. Vägnummer matchas exakt; lägg till * sist för ett nummerprefix (till exempel 71*). Vägnamn matchas utan hänsyn till stora och små bokstäver.",
           "road_filter_safety_bypass": "Om aktiverat visas händelser markerade som säkerhetsrelaterade av Trafikverket oavsett vägfilter. 'Viktig trafikinformation' visas alltid oavsett den här inställningen. Inaktiverat innebär att vägfiltret gäller strikt för alla händelsetyper, inklusive Trafikmeddelande."
         }
       },

--- a/custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
+++ b/custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js
@@ -511,9 +511,7 @@ class TrafikinfoSeAlertCard extends LitElement {
       const sev = this._severityBucket(e);
       // Important traffic info typically has no severity; ignore severity filter there
       const sevOk = preset === 'important' || filterSev.length === 0 || filterSev.includes(sev);
-      const roadText = `${e.road_name || ''} ${e.road_number || ''}`.toLowerCase();
-      const roadNo = String(e.road_number || '').trim().toLowerCase();
-      const roadOk = filterRoads.length === 0 || filterRoads.some((x) => (roadText.includes(x) || (roadNo && x === roadNo)));
+      const roadOk = filterRoads.length === 0 || this._roadFilterMatch(e, filterRoads);
       return sevOk && roadOk;
     });
 
@@ -574,6 +572,25 @@ class TrafikinfoSeAlertCard extends LitElement {
     // Normalize whitespace
     s = s.replace(/\s+/g, ' ').trim();
     return s;
+  }
+
+  _roadFilterMatch(item, tokens) {
+    const roadNo = this._normalizeRoadFilterToken(item?.road_number);
+    const roadName = String(item?.road_name || '').toLowerCase().replace(/\s+/g, ' ').trim();
+
+    return tokens.some((token) => {
+      if (!token) return false;
+
+      const wildcardCount = (token.match(/\*/g) || []).length;
+      if (token.endsWith('*') && wildcardCount === 1) {
+        const prefix = token.slice(0, -1).trim();
+        return Boolean(prefix && roadNo.startsWith(prefix));
+      }
+
+      if (token.includes('*')) return false;
+      if (/\d/.test(token)) return Boolean(roadNo && token === roadNo);
+      return roadName.includes(token);
+    });
   }
 
   _severityRank(item) {
@@ -2728,7 +2745,7 @@ class TrafikinfoSeAlertCardEditor extends LitElement {
           { value: 'road', label: 'By road' },
           { value: 'severity', label: 'By severity' },
         ] } } },
-        { name: 'filter_roads', label: 'Filter roads (comma/semicolon-separated)', selector: { text: {} } },
+        { name: 'filter_roads', label: 'Filter roads (exact numbers/names; 71* for prefixes; comma/semicolon-separated)', selector: { text: {} } },
       );
     }
     if (preset !== 'important') {
@@ -2999,7 +3016,7 @@ class TrafikinfoSeAlertCardEditor extends LitElement {
       date_format: 'Date format',
       group_by: 'Group by',
       filter_severities: 'Filter severities',
-      filter_roads: 'Filter roads (comma/semicolon-separated)',
+      filter_roads: 'Filter roads (exact numbers/names; 71* for prefixes; comma/semicolon-separated)',
       tap_action: 'Tap action',
       double_tap_action: 'Double tap action',
       hold_action: 'Hold action',

--- a/tests/trafikinfo-road-filter.test.mjs
+++ b/tests/trafikinfo-road-filter.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { copyFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const registeredElements = new Map();
+const templateTag = (strings, ...values) => ({ strings, values });
+
+globalThis.window = {
+  LitElement: class {},
+  litHtml: { html: templateTag, css: templateTag },
+  location: {
+    href: 'http://homeassistant.local:8123/lovelace/test',
+    origin: 'http://homeassistant.local:8123',
+  },
+  customCards: [],
+};
+globalThis.customElements = {
+  define: (name, elementClass) => registeredElements.set(name, elementClass),
+  get: (name) => registeredElements.get(name),
+};
+
+const cardUrl = new URL(
+  '../custom_components/trafikinfo_se/www/trafikinfo-se-alert-card.js',
+  import.meta.url,
+);
+const testDirectory = await mkdtemp(join(tmpdir(), 'trafikinfo-card-test-'));
+const testCardPath = join(testDirectory, 'trafikinfo-se-alert-card.mjs');
+await copyFile(fileURLToPath(cardUrl), testCardPath);
+after(() => rm(testDirectory, { recursive: true, force: true }));
+await import(pathToFileURL(testCardPath).href);
+
+const AlertCard = registeredElements.get('trafikinfo-se-alert-card');
+
+function event(roadNumber, roadName) {
+  return {
+    event_key: `event-${roadNumber}`,
+    road_number: roadNumber,
+    road_name: roadName,
+    severity_code: 2,
+  };
+}
+
+function visibleRoads(filterRoads, events) {
+  const card = new AlertCard();
+  card.config = {
+    entity: 'sensor.test_accidents',
+    filter_roads: filterRoads,
+    filter_severities: [],
+    preset: 'accident',
+  };
+  card.hass = {
+    states: {
+      'sensor.test_accidents': { attributes: { events } },
+    },
+  };
+  card._pendingDismiss = new Set();
+
+  return card._visibleEvents().map((item) => item.road_number);
+}
+
+test('plain road numbers use exact matching', () => {
+  const events = [
+    event('84', 'Väg 84'),
+    event('848', 'Vallervägen (Väg 848)'),
+    event('E4', 'Europaväg E4'),
+    event('E45', 'Europaväg E45'),
+  ];
+
+  assert.deepEqual(visibleRoads('84; E4', events), ['84', 'E4']);
+});
+
+test('a trailing wildcard enables road-number prefix matching', () => {
+  const events = [
+    event('71', 'Väg 71'),
+    event('712', 'Väg 712'),
+    event('713', 'Väg 713'),
+    event('715', 'Väg 715'),
+    event('72', 'Väg 72'),
+  ];
+
+  assert.deepEqual(visibleRoads('Väg 71*', events), ['71', '712', '713', '715']);
+});
+
+test('road names keep case-insensitive partial matching', () => {
+  const events = [
+    event('848', 'Vallervägen (Väg 848)'),
+    event('84', 'Landsvägen (Väg 84)'),
+  ];
+
+  assert.deepEqual(visibleRoads('VALLER', events), ['848']);
+});
+
+test('unsupported wildcard forms do not match', () => {
+  const events = [event('711', 'Väg 711'), event('848', 'Vallervägen (Väg 848)')];
+
+  assert.deepEqual(visibleRoads('*, 7*1', events), []);
+});


### PR DESCRIPTION
Road-number filters now match exact values, so road 84 no longer includes road 848 and E4 no longer includes E45. Both the Trafikinfo SE integration and alert card now support trailing wildcards such as 71* for optional prefix matching, while retaining flexible road-name matching. Existing filters require no changes. Fixes #98.

## Summary

Describe what changed and why.

## Component

- [X] Integration
- [X] Alert Card
- [ ] CI/Docs/Other

## Validation

- [X] I ran relevant local checks
- [X] I verified release note impact
- [X] I used Conventional Commit format with scope when relevant

## Notes

Include rollout or migration notes if needed.
