### PR TITLE
chore: Allow manual release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [beta, main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a manual trigger for the release workflow so a release can be safely restarted if a GitHub Actions incident leaves a run stuck.